### PR TITLE
- Added a @Retry annotation to specify which method to retry

### DIFF
--- a/src/main/java/com/jbaxenom/laget/configuration/Retry.java
+++ b/src/main/java/com/jbaxenom/laget/configuration/Retry.java
@@ -1,0 +1,22 @@
+package com.jbaxenom.laget.configuration;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+
+/**
+ * Created by jdelbarc on 02/11/16.
+ */
+@Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@Target({METHOD, TYPE, CONSTRUCTOR})
+public @interface Retry {
+
+    /**
+     * the maximum amount of times the test should be run (original + retries).
+     */
+    public int count() default 3;
+
+}

--- a/src/main/java/com/jbaxenom/laget/configuration/RetryAnalyzer.java
+++ b/src/main/java/com/jbaxenom/laget/configuration/RetryAnalyzer.java
@@ -9,12 +9,15 @@ import org.testng.ITestResult;
  *
  * @author chema.delbarco
  */
-public class RetryAnalyzer implements IRetryAnalyzer {
+public abstract class RetryAnalyzer implements IRetryAnalyzer {
 
-    // Change this value to enable retries on failure
-    public static final int MAX_RETRY_COUNT = 1;
+    protected static int MAX_RUN_COUNT;
 
-    private final ThreadLocal<Integer> count = new ThreadLocal<Integer>() {
+    /**
+     * stores the current count of test retries in a thread-safe variable to ensure it works in
+     * concurrent test runs
+     */
+    protected final ThreadLocal<Integer> count = new ThreadLocal<Integer>() {
 
         @Override
         protected synchronized Integer initialValue() {
@@ -24,12 +27,18 @@ public class RetryAnalyzer implements IRetryAnalyzer {
     };
 
     public boolean retry(ITestResult result) {
+        return false;
+    }
+
+    public boolean processRetry(ITestResult result) {
+        // Increment counter
         count.set(count.get() + 1);
 
-        if (count.get() <= MAX_RETRY_COUNT) {
-            System.out.println("Retrying test: " + result.getName() + ". Retry count: " + count.get());
+        if (count.get() < MAX_RUN_COUNT) {
+            System.out.println("\nTest " + result.getName() + " Failed. Retrying! (count: " + count.get() + ")\n");
             return true;
         } else {
+            System.out.println("\nTest " + result.getName() + " failed after " + count.get() + " runs. Marking it as FAILED\n");
             return false;
         }
     }

--- a/src/main/java/com/jbaxenom/laget/configuration/RetryAnnotationRetryAnalyzer.java
+++ b/src/main/java/com/jbaxenom/laget/configuration/RetryAnnotationRetryAnalyzer.java
@@ -1,0 +1,31 @@
+package com.jbaxenom.laget.configuration;
+
+import org.testng.ITestResult;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * Implementation of TestNG's retry analyzer.
+ * <p>Stores the logic for retrying test methods.
+ *
+ * @author chema.delbarco
+ */
+public class RetryAnnotationRetryAnalyzer extends RetryAnalyzer {
+
+    public boolean retry(ITestResult result) {
+
+        // If it's the first time retrying, set MAX_RUN_COUNT to the "count" value in the Retry
+        // annotation or default to 1 (no retry) if the annotation is not used
+
+        Annotation retryAnnotation =
+            result.getMethod().getConstructorOrMethod().getMethod().getAnnotation(Retry.class);
+
+        if (count.get() == 0) {
+            MAX_RUN_COUNT = (retryAnnotation == null)
+                ? 1
+                : ((Retry) retryAnnotation).count();
+        }
+
+        return processRetry(result);
+    }
+}

--- a/src/main/java/com/jbaxenom/laget/configuration/RetryAnnotationTransformer.java
+++ b/src/main/java/com/jbaxenom/laget/configuration/RetryAnnotationTransformer.java
@@ -8,16 +8,19 @@ import java.lang.reflect.Method;
 
 
 /**
- * Implementation of TestNG's annotation transformer to include automatic retry on error in any test using the @Test
- * annotation
+ * Implementation of TestNG's annotation transformer to include automatic retry on error in any
+ * test using the @Retry annotation
  *
  * @author chema.delbarco
  */
-public class AnnotationTransformer implements IAnnotationTransformer {
+public class RetryAnnotationTransformer implements IAnnotationTransformer {
 
   public synchronized void transform(ITestAnnotation annotation, Class testClass,
                                      Constructor testConstructor, Method testMethod) {
-    annotation.setTimeOut(360000);
-    annotation.setRetryAnalyzer(RetryAnalyzer.class);
+
+      if (testMethod.isAnnotationPresent(Retry.class)) {
+          annotation.setRetryAnalyzer(RetryAnnotationRetryAnalyzer.class);
+      }
+
   }
 }

--- a/src/main/java/com/jbaxenom/laget/configuration/TestAnnotationRetryAnalyzer.java
+++ b/src/main/java/com/jbaxenom/laget/configuration/TestAnnotationRetryAnalyzer.java
@@ -1,0 +1,21 @@
+package com.jbaxenom.laget.configuration;
+
+import org.testng.ITestResult;
+
+/**
+ * Implementation of TestNG's retry analyzer.
+ * <p>Stores the logic for retrying test methods.
+ *
+ * @author chema.delbarco
+ */
+public class TestAnnotationRetryAnalyzer extends RetryAnalyzer {
+
+    @Override
+    public boolean retry(ITestResult result) {
+
+        // Change this value to the max amount of times you want the test to run (original + retry)
+        MAX_RUN_COUNT = 2;
+
+        return processRetry(result);
+    }
+}

--- a/src/main/java/com/jbaxenom/laget/configuration/TestAnnotationTransformer.java
+++ b/src/main/java/com/jbaxenom/laget/configuration/TestAnnotationTransformer.java
@@ -1,0 +1,26 @@
+package com.jbaxenom.laget.configuration;
+
+import org.testng.IAnnotationTransformer;
+import org.testng.annotations.ITestAnnotation;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+
+/**
+ * Implementation of TestNG's annotation transformer to include automatic retry on error in any test
+ * using the @Test annotation
+ *
+ * @author chema.delbarco
+ */
+public class TestAnnotationTransformer implements IAnnotationTransformer {
+
+  public synchronized void transform(ITestAnnotation annotation, Class testClass,
+                                     Constructor testConstructor, Method testMethod) {
+
+      if (testMethod.isAnnotationPresent(Retry.class)) {
+          annotation.setRetryAnalyzer(TestAnnotationRetryAnalyzer.class);
+      }
+
+  }
+}

--- a/src/test/java/com/jbaxenom/laget/examples/ActorsActionsExampleTest.java
+++ b/src/test/java/com/jbaxenom/laget/examples/ActorsActionsExampleTest.java
@@ -1,5 +1,6 @@
 package com.jbaxenom.laget.examples;
 
+import com.jbaxenom.laget.configuration.Retry;
 import com.jbaxenom.laget.domain.examples.actors.ExampleWebUser;
 import org.testng.annotations.*;
 
@@ -12,18 +13,20 @@ public class ActorsActionsExampleTest {
 
     private ExampleWebUser webUser;
 
-    @BeforeClass
+    @BeforeMethod
     public void setup() {
+
         // GIVEN there is a user with username "chema" and password "pass"
         webUser = new ExampleWebUser("chema", "pass");
     }
 
-    @AfterClass
+    @AfterMethod
     public void tearDown() {
         webUser.closeBrowser();
     }
 
     @Test
+    @Retry(count = 3)
     public void actorsAndActionsExampleTest() {
 
         // WHEN the user performs its example web action, THEN he does it successfully


### PR DESCRIPTION
You can define the total amount of times it should be run using parameter "count" (original run + retries). To use this you need to add "RetryAnnotationTransformer.class" as a listener. Alternatively you can add the "TestAnnotationTransformer.class" listener to retry on failure all tests that use the @Test annotation, which was the default behaviour implemented before